### PR TITLE
increase hard limit on configuration size to 131072 from 65536

### DIFF
--- a/include/vacuumms/limits.h
+++ b/include/vacuumms/limits.h
@@ -1,4 +1,4 @@
 /* vacuumms/limits.h */
 
-#define VACUUMMS_MAX_NUMBER_OF_MOLECULES 65536
+#define VACUUMMS_MAX_NUMBER_OF_MOLECULES 131072
 #define VACUUMMS


### PR DESCRIPTION
There should be no reason not to merge this. The largest structure dependent on this value is still less than 16MB (all atoms in a gfg plus their 26 mirror box replicas). 